### PR TITLE
closing foreground process after tunnel starts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ dist
 # TernJS port file
 .tern-port
 dist/
+
+.DS_Store
+.lambdatest/
+tunnel_local_pid

--- a/scripts/lt-tunnel-start.js
+++ b/scripts/lt-tunnel-start.js
@@ -19,4 +19,6 @@ const tunnelArguments = {
     } catch (error) {
         console.log(error);
     }
+    // exit this script once tunnel is started
+    process.exit(0)
 })();

--- a/scripts/tunnel-stop.js
+++ b/scripts/tunnel-stop.js
@@ -1,4 +1,5 @@
 const { existsSync, readFileSync } = require("fs");
+const childProcess = require('child_process')
 
 const pidFile = "tunnel_local_pid";
 
@@ -13,7 +14,8 @@ const stop = () => {
     const pid = readPidFile();
     if (pid) {
         console.log("Stopping local tunnel with pid :", pid);
-        process.kill(pid);
+        //process.kill(pid);
+        childProcess.exec('kill -9 ' + pid);
     }
 };
 


### PR DESCRIPTION
1. Added  process.exit(0) to tunnel start script
2. used childProcess.exec('kill -9 ' + pid); to stop tunnel